### PR TITLE
Webpack: Fix eslint-loader exclude paths

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,7 +14,7 @@ module.exports = {
     rules: [
       {
         test: /\.(js|jsx)$/,
-        exclude: /node_modules|src\/application\/assets/,
+        exclude: [/node_modules/, path.join(__dirname, 'src/application/assets/')],
         enforce: "pre",
         loader: "eslint-loader",
         options: {


### PR DESCRIPTION
This PR solve #3 issue.