### PR TITLE
react-app : State / Store

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,6 +16,7 @@
         "aspects": ["noHref", "invalidHref", "preferButton"]
       }
     ],
+    "max-len": ["error", { "code": 140 }],
     "comma-dangle": 0,
     "jsx-a11y/click-events-have-key-events": 0,
     "jsx-a11y/no-static-element-interactions": 0

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "html-webpack-plugin": "3.0.6",
     "node-sass": "4.7.2",
     "postcss-loader": "2.1.1",
+    "prettier": "1.11.1",
     "sass-loader": "6.0.7",
     "sass-resources-loader": "1.3.3",
     "style-loader": "0.20.3",

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  printWidth: 140
+};

--- a/src/application/common/withStore.js
+++ b/src/application/common/withStore.js
@@ -1,4 +1,10 @@
 import React, { Component } from "react";
+import { findKey, keys, includes } from "lodash";
+
+const findFirstExistingStateKeyInProps = (state, props) => {
+  const propsKeys = keys(props);
+  return findKey(state, (value, key) => includes(propsKeys, key));
+};
 
 export default (WrappedComponent, store) =>
   class extends Component {
@@ -21,6 +27,10 @@ export default (WrappedComponent, store) =>
     }
 
     render() {
-      return <WrappedComponent data={this.state} {...this.props} />;
+      const existingStateKeyInProps = findFirstExistingStateKeyInProps(this.state, this.props);
+      if (existingStateKeyInProps) {
+        throw new Error(`Error. Property ${existingStateKeyInProps} already exist.`);
+      }
+      return <WrappedComponent {...this.state} {...this.props} />;
     }
   };

--- a/src/application/components/FirstPage/index.js
+++ b/src/application/components/FirstPage/index.js
@@ -9,7 +9,7 @@ import withStore from "../../common/withStore";
 import withResetStoreOnMountAndUnMount from "../../common/withResetStoreOnMountAndUnMount";
 import store from "./store";
 
-const FirstPage = ({ data: { firstPageClicksCount } }) => (
+const FirstPage = ({ firstPageClicksCount }) => (
   <div className="FirstPage" onClick={() => store.set({ firstPageClicksCount: firstPageClicksCount + 1 })}>
     <Links />
     <div className="FirstPage__clicks">{`FirstPage clicks: ${firstPageClicksCount}`}</div>
@@ -22,9 +22,7 @@ const FirstPage = ({ data: { firstPageClicksCount } }) => (
 );
 
 FirstPage.propTypes = {
-  data: PropTypes.shape({
-    firstPageClicksCount: PropTypes.number.isRequired
-  }).isRequired
+  firstPageClicksCount: PropTypes.number.isRequired
 };
 
 export default withResetStoreOnMountAndUnMount(withStore(FirstPage, store), store);

--- a/src/application/components/Home/index.js
+++ b/src/application/components/Home/index.js
@@ -5,16 +5,14 @@ import withResetStoreOnMountAndUnMount from "../../common/withResetStoreOnMountA
 import store from "./store";
 import "./Home.scss";
 
-const Home = ({ data: { homePageClicksCount } }) => (
+const Home = ({ homePageClicksCount }) => (
   <div className="Home" onClick={() => store.set({ homePageClicksCount: homePageClicksCount + 1 })}>
     <div className="Home__clicks">{`Home clicks: ${homePageClicksCount}`}</div>
   </div>
 );
 
 Home.propTypes = {
-  data: PropTypes.shape({
-    homePageClicksCount: PropTypes.number.isRequired
-  }).isRequired
+  homePageClicksCount: PropTypes.number.isRequired
 };
 
 export default withResetStoreOnMountAndUnMount(withStore(Home, store), store);

--- a/src/application/components/SomeComponentInner/index.js
+++ b/src/application/components/SomeComponentInner/index.js
@@ -2,18 +2,20 @@ import React from "react";
 import PropTypes from "prop-types";
 import "./SomeComponentInner.scss";
 import withStore from "../../common/withStore";
-import store from "../FirstPage/store";
+import withResetStoreOnMountAndUnMount from "../../common/withResetStoreOnMountAndUnMount";
+import firstPageStore from "../FirstPage/store";
+import store from "./store";
 
-const SomeComponentInner = ({ data: { firstPageClicksCount } }) => (
-  <div className="SomeComponentInner">
+const SomeComponentInner = ({ firstPageClicksCount, someComponentInnerClicksCount }) => (
+  <div className="SomeComponentInner" onClick={() => store.set({ someComponentInnerClicksCount: someComponentInnerClicksCount + 1 })}>
     <div className="SomeComponentInner__clicks">{`FirstPage clicks: ${firstPageClicksCount}`}</div>
+    <div className="SomeComponentInner__clicks">{`SomeComponentInner clicks: ${someComponentInnerClicksCount}`}</div>
   </div>
 );
 
 SomeComponentInner.propTypes = {
-  data: PropTypes.shape({
-    firstPageClicksCount: PropTypes.number.isRequired
-  }).isRequired
+  firstPageClicksCount: PropTypes.number.isRequired,
+  someComponentInnerClicksCount: PropTypes.number.isRequired
 };
 
-export default withStore(SomeComponentInner, store);
+export default withStore(withResetStoreOnMountAndUnMount(withStore(SomeComponentInner, store), store), firstPageStore);

--- a/src/application/components/SomeComponentInner/store.js
+++ b/src/application/components/SomeComponentInner/store.js
@@ -1,0 +1,5 @@
+import Store from "../../common/store";
+
+class SomeComponentInnerStore extends Store {}
+
+export default new SomeComponentInnerStore({ someComponentInnerClicksCount: 0 });


### PR DESCRIPTION
- fix eslint rule
- not allow to use props with same name, to avoid override
- add prettier configuration
- base example how to use two or more stores for one component